### PR TITLE
Add support for mvnd

### DIFF
--- a/mavenpy/tests/test.py
+++ b/mavenpy/tests/test.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 
+from shutil import which
 from mavenpy.run import Maven
 
 _DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
@@ -8,12 +9,24 @@ _DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
 
 class Test(unittest.TestCase):
   def test_maven_run(self):
+    print("test_maven_run")
     maven = Maven()
     maven.batch = True
     maven.debug = True
     maven.run_in_dir(_DATA_DIR, "clean", "verify")
 
+  @unittest.skipIf(which("mvnd") == None,
+                   "requires mvnd command on path")
+  def test_maven_daemon_run(self):
+    print("test_maven_daemon_run")
+    maven = Maven()
+    maven.batch = True
+    maven.debug = True
+    maven.daemon = True
+    maven.run_in_dir(_DATA_DIR, "clean", "verify")
+
   def test_maven_version(self):
+    print("test_maven_version")
     maven = Maven()
     v = maven.get_version()
     self.assertNotEqual("", v)    # e.g., "3.6.0"


### PR DESCRIPTION
The added `threads` option makes sure the default while running `mvnd` is still to use only a single thread. This is the default for `mvn`, but `mvnd` will try to compile multiple modules at once in a reactor build when maven thinks they are independent (i.e. it passes `--threads "C-1"` to maven). Since `mavenpy` is mostly used by a build script that has problems with multi-threaded maven builds, this seemed like a safer default.